### PR TITLE
Body content should not always be encoded.

### DIFF
--- a/lib/Elastijk.pm
+++ b/lib/Elastijk.pm
@@ -30,7 +30,11 @@ sub request {
     my $arg = $_[0];
     if ($arg->{body}) {
         $arg = {%{$_[0]}};
-        $arg->{body} = $JSON->encode( $arg->{body} );
+        if ( ref($arg->{body}) eq 'HASH' or ref($arg->{body}) eq 'ARRAY' ) {
+            $arg->{body} = $JSON->encode( $arg->{body} );
+        } else {
+            $arg->{body} = "$arg->{body}";
+        }
     }
     my ($status, $res_body) = request_raw($arg);
     $res_body = $res_body ? eval { $JSON->decode($res_body) } : undef;


### PR DESCRIPTION
ES accepts the scroll_id being sent via the body of the request. In this case, it should not be encoded in JSON.

For more information on the motivation for this request, see:

https://github.com/dostermeier/es-utils/commit/2eea122cf0732ac98c6f50ae67377ad0d538592a

and 

https://github.com/reyjrar/es-utils/pull/22
